### PR TITLE
Add support for anonymous enums

### DIFF
--- a/GAS/cc_aarch64.S
+++ b/GAS/cc_aarch64.S
@@ -656,6 +656,10 @@ fputc:
     pop x1
     ret
 
+enum_error_open_curly: .asciz "ERROR in enum\nExpected {\n"
+enum_error_equal: .asciz "ERROR in enum\nExpected =\n"
+enum_error_close_curly: .asciz "ERROR in enum\nExpected }\n"
+enum_error_semi_colon: .asciz "ERROR in enum\nExpected ;\n"
 
 // program function
 // receives nothing, returns nothing
@@ -667,6 +671,93 @@ program:
     push x2                     // Protect X2
 
 new_type:
+    adr x9, global_token        // Using global_token
+    ldr x0, [x9]
+    cmp x0, 0                   // Check if NULL
+    b.eq program_done           // Be done if null
+
+    ldr x1, [x0,16]             // GLOBAL_TOKEN->S
+    adr x0, enum                // "enum"
+    bl match                    // IF GLOBAL_TOKEN->S == "enum"
+    cmp x0, 0                   // If true
+    b.ne constant_value         // Looks like not an enum
+
+    // Deal with minimal anonymous enums
+    adr x9, global_token           // Using global_token
+    ldr x0, [x9]
+    ldr x0, [x0]                   // global_token->next
+    adr x9, global_token           // global_token = global_token->next
+    str x0, [x9]
+
+    adr x0, enum_error_open_curly  // Using "ERROR in enum\nExpected {\n"
+    adr x1, open_curly_brace       // Using "{"
+    bl require_match               // Require match and skip
+
+enumerator:
+    adr x9, global_token           // Using global_token
+    ldr x0, [x9]
+
+    ldr x0, [x0,16]                // global_token->S
+    mov x1, 0                      // NULL
+    adr x9, global_constant_list   // global_constant_list
+    ldr x2, [x9]
+    bl sym_declare                 // Declare that constant
+    adr x9, global_constant_list   // global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+    str x0, [x9]
+
+    adr x9, global_token           // Using global_token
+    ldr x0, [x9]
+    ldr x0, [x0]                   // global_token->next
+    adr x9, global_token           // global_token = global_token->next
+    str x0, [x9]
+
+    adr x0, enum_error_equal       // Using "ERROR in enum\nExpected =\n"
+    adr x1, equal                  // Using "="
+    bl require_match               // Require match and skip
+
+    adr x9, global_constant_list   // global_constant_list
+    ldr x0, [x9]
+    adr x9, global_token           // Using global_token
+    ldr x1, [x9]
+    str x1, [x0,32]                // global_constant_list->arguments = global_token
+
+    adr x9, global_token           // Using global_token
+    ldr x0, [x9]
+    ldr x0, [x0]                   // global_token->next
+    adr x9, global_token           // global_token = global_token->next
+    str x0, [x9]
+
+    ldr x1, [x0,16]                // GLOBAL_TOKEN->S
+    adr x0, comma                  // ","
+    bl match                       // IF GLOBAL_TOKEN->S == ","
+    cmp x0, 0                      // If true
+    b.ne enum_end                  // No more enumerators
+
+    // Skip comma
+    adr x9, global_token           // Using global_token
+    ldr x0, [x9]
+    ldr x0, [x0]                   // global_token->next
+    adr x9, global_token           // global_token = global_token->next
+    str x0, [x9]
+
+    ldr x1, [x0,16]                // GLOBAL_TOKEN->S
+    adr x0, close_curly_brace      // "}"
+    bl match                       // IF GLOBAL_TOKEN->S == "}"
+    cmp x0, 0                      // If true
+    b.ne enumerator                // There are additional enumerators
+
+enum_end:
+    adr x0, enum_error_close_curly // Using "ERROR in enum\nExpected }\n"
+    adr x1, close_curly_brace      // Using "}"
+    bl require_match               // Require match and skip
+
+    adr x0, enum_error_semi_colon  // Using "ERROR in enum\nExpected ;\n"
+    adr x1, semicolon              // Using ";"
+    bl require_match               // Require match and skip
+
+    b new_type
+
+constant_value:
     adr x9, global_token        // Using global_token
     ldr x0, [x9]
     cmp x0, 0                   // Check if NULL
@@ -4777,6 +4868,7 @@ strings_list: .quad 0
 // Keywords
 union: .asciz "union"
 struct: .asciz "struct"
+enum: .asciz "enum"
 constant: .asciz "CONSTANT"
 main_string: .asciz "main"
 argc_string: .asciz "argc"

--- a/cc_aarch64.M1
+++ b/cc_aarch64.M1
@@ -1227,6 +1227,147 @@ DEFINE RBRANCH 17
     ^~program_done FBRANCH
 
     LDR_X1_[X0,16]                      # GLOBAL_TOKEN->S
+    LOAD_W0_AHEAD                       # "enum"
+    SKIP_32_DATA
+    &enum
+    ^~match FCALL                       # IF GLOBAL_TOKEN->S == "enum"
+    CMP_X0_TO_0                         # If true
+    SKIP_INST_EQ                        # Looks like not an enum
+    ^~constant_value FBRANCH
+
+    # Deal with minimal anonymous enums
+    LOAD_W9_AHEAD                       # Using global_token
+    SKIP_32_DATA
+    &global_token
+    LDR_X0_[X9]
+    LDR_X0_[X0]                         # global_token->next
+    LOAD_W9_AHEAD                       # global_token = global_token->next
+    SKIP_32_DATA
+    &global_token
+    STR_X0_[X9]
+
+    LOAD_W0_AHEAD                       # Using "ERROR in enum\nExpected {\n"
+    SKIP_32_DATA
+    &enum_error_open_curly
+    LOAD_W1_AHEAD                       # Using "{"
+    SKIP_32_DATA
+    &open_curly_brace
+    ^~require_match FCALL               # Require match and skip
+
+:enumerator
+    LOAD_W9_AHEAD                       # Using global_token
+    SKIP_32_DATA
+    &global_token
+    LDR_X0_[X9]
+
+    LDR_X0_[X0,16]                      # global_token->S
+    SET_X1_TO_0                         # NULL
+    LOAD_W9_AHEAD                       # global_constant_list
+    SKIP_32_DATA
+    &global_constant_list
+    LDR_X2_[X9]
+    ^~sym_declare FCALL                 # Declare that constant
+    LOAD_W9_AHEAD                       # global_constant_list = sym_declare(global_token->s, NULL, global_constant_list)#
+    SKIP_32_DATA
+    &global_constant_list
+    STR_X0_[X9]
+
+    LOAD_W9_AHEAD                       # Using global_token
+    SKIP_32_DATA
+    &global_token
+    LDR_X0_[X9]
+    LDR_X0_[X0]                         # global_token->next
+    LOAD_W9_AHEAD                       # global_token = global_token->next
+    SKIP_32_DATA
+    &global_token
+    STR_X0_[X9]
+
+    LOAD_W0_AHEAD                       # Using "ERROR in enum\nExpected =\n"
+    SKIP_32_DATA
+    &enum_error_equal
+    LOAD_W1_AHEAD                       # Using "="
+    SKIP_32_DATA
+    &equal
+    ^~require_match FCALL               # Require match and skip
+
+    LOAD_W9_AHEAD                       # global_constant_list
+    SKIP_32_DATA
+    &global_constant_list
+    LDR_X0_[X9]
+    LOAD_W9_AHEAD                       # Using global_token
+    SKIP_32_DATA
+    &global_token
+    LDR_X1_[X9]
+    STR_X1_[X0,32]                      # global_constant_list->arguments = global_token
+
+    LOAD_W9_AHEAD                       # Using global_token
+    SKIP_32_DATA
+    &global_token
+    LDR_X0_[X9]
+    LDR_X0_[X0]                         # global_token->next
+    LOAD_W9_AHEAD                       # global_token = global_token->next
+    SKIP_32_DATA
+    &global_token
+    STR_X0_[X9]
+
+    LDR_X1_[X0,16]                      # GLOBAL_TOKEN->S
+    LOAD_W0_AHEAD                       # ","
+    SKIP_32_DATA
+    &comma
+    ^~match FCALL                       # IF GLOBAL_TOKEN->S == ","
+    CMP_X0_TO_0                         # If true
+    SKIP_INST_EQ                        # No more enumerators
+    ^~enum_end FBRANCH
+
+    # Skip comma
+    LOAD_W9_AHEAD                       # Using global_token
+    SKIP_32_DATA
+    &global_token
+    LDR_X0_[X9]
+    LDR_X0_[X0]                         # global_token->next
+    LOAD_W9_AHEAD                       # global_token = global_token->next
+    SKIP_32_DATA
+    &global_token
+    STR_X0_[X9]
+
+    LDR_X1_[X0,16]                      # GLOBAL_TOKEN->S
+    LOAD_W0_AHEAD                       # "}"
+    SKIP_32_DATA
+    &close_curly_brace
+    ^~match FCALL                       # IF GLOBAL_TOKEN->S == "}"
+    CMP_X0_TO_0                         # If true
+    SKIP_INST_EQ                        # There are no additional enumerators
+    ^~enumerator RBRANCH
+
+:enum_end
+    LOAD_W0_AHEAD                       # Using "ERROR in enum\nExpected }\n"
+    SKIP_32_DATA
+    &enum_error_close_curly
+    LOAD_W1_AHEAD                       # Using "}"
+    SKIP_32_DATA
+    &close_curly_brace
+    ^~require_match FCALL               # Make sure it has the required
+
+    LOAD_W0_AHEAD                       # Using "ERROR in enum\nExpected }\n"
+    SKIP_32_DATA
+    &enum_error_semi_colon
+    LOAD_W1_AHEAD                       # Using "}"
+    SKIP_32_DATA
+    &semicolon
+    ^~require_match FCALL               # Make sure it has the required
+
+    ^~new_type RBRANCH                  # go around again
+
+:constant_value
+    LOAD_W9_AHEAD                       # Using global_token
+    SKIP_32_DATA
+    &global_token
+    LDR_X0_[X9]
+    CMP_X0_TO_0                         # Check if NULL
+    SKIP_INST_NE                        # Be done if null
+    ^~program_done FBRANCH
+
+    LDR_X1_[X0,16]                      # GLOBAL_TOKEN->S
     LOAD_W0_AHEAD                       # "CONSTANT"
     SKIP_32_DATA
     &constant
@@ -6651,6 +6792,7 @@ DEFINE RBRANCH 17
 ;; Keywords
 :union  "union"
 :struct  "struct"
+:enum  "enum"
 :constant  "CONSTANT"
 :main_string  "main"
 :argc_string  "argc"
@@ -6738,6 +6880,19 @@ DEFINE RBRANCH 17
 :program_string_1
 "
 NULL
+"
+
+:enum_error_open_curly "ERROR in enum
+Expected {
+"
+:enum_error_equal "ERROR in enum
+Expected =
+"
+:enum_error_close_curly "ERROR in enum
+Expected }
+"
+:enum_error_semi_colon "ERROR in enum
+Expected ;
 "
 
 :declare_function_string_0  "# Defining function "


### PR DESCRIPTION
@stikonas @oriansj 

Same as the others except I can't get this one to work.

Test file:
```c
// CONSTANT TEST5 5
enum {
    TEST1 = 1,
    TEST2 = 2
};

enum {
    TEST3 = 3,
    TEST4 = 4,
};

int main() {
    return TEST1 + TEST2 + TEST3 + TEST4 + TEST5;
}
```

Which fails on M1 but works with the real assembly file. I'm not sure what I'm doing wrong but I've been through all the commands several times to ensure that they are identical to the proper assembly version.
I've come to the conclusion that I must be doing something that `M1` can't handle but I'm not sure what.
The bootstrapped version is a nightmare to debug since there are no labels and `gdb` doesn't handle the decoding of the (many) 32 bit literal loads very well.

Am I understanding it correctly that the best way of debugging is with `blood-elf -f AArch64/cc_aarch64.M1 -o /tmp/cc_aarch64.M1 --little-endian && M1 -f AArch64/cc_aarch64.M1 -o /tmp/cc_aarch64.hex2 && hex2 -f ./AArch64/ELF-aarch64.hex2 -f /tmp/cc_aarch64.hex2 -o /tmp/cc_aarch64`? I'm unable to run the resulting file and getting error `aarch64-binfmt-P: /tmp/cc_aarch64: Incomplete read of file header`.