### PR TITLE
Harden cc_aarch64 against malformed input

### DIFF
--- a/GAS/cc_aarch64.S
+++ b/GAS/cc_aarch64.S
@@ -242,12 +242,16 @@ get_token_comment:
 get_token_comment_block_outer:
     adr x9, C                   // Using C
     ldr x0, [x9]
+    cmp x0, -4                  // Check for EOF
+    b.eq reset                  // Stop if the comment was not closed
     cmp x0, 47                  // IF '/' != C
     b.eq get_token_comment_block_done   // be done
 
 get_token_comment_block_inner:
     adr x9, C                   // Using C
     ldr x0, [x9]
+    cmp x0, -4                  // Check for EOF
+    b.eq reset                  // Stop if the comment was not closed
     cmp x0, 42                  // IF '*' != C
     b.eq get_token_comment_block_iter   // jump over
 
@@ -382,8 +386,11 @@ purge_macro:
     push x30
 purge_macro_loop:
     bl fgetc                    // read next char
+    cmp x0, -4                  // Check for EOF
+    b.eq purge_macro_done       // Done if EOF
     cmp x0, 10                  // Check for '\n'
     b.ne purge_macro_loop       // Keep going
+purge_macro_done:
     pop x30
     ret
 
@@ -479,6 +486,8 @@ consume_word_escape:
 
 consume_word_iter:
     bl consume_byte             // read next char
+    cmp x0, -4                  // Check for EOF
+    b.eq consume_word_done      // Stop if the string was not closed
 
     cmp x2, 0                   // IF ESCAPE
     b.ne consume_word_loop      // keep looping
@@ -486,6 +495,7 @@ consume_word_iter:
     cmp x0, x1                  // IF C != FREQ
     b.ne consume_word_loop      // keep going
 
+consume_word_done:
     bl fgetc                    // return next char
     pop x2                      // Restore X2
     pop x1                      // Restore X1
@@ -694,6 +704,7 @@ new_type:
     bl require_match               // Require match and skip
 
 enumerator:
+    bl require_global_token       // Ensure global_token is not EOF
     adr x9, global_token           // Using global_token
     ldr x0, [x9]
 
@@ -715,6 +726,7 @@ enumerator:
     adr x1, equal                  // Using "="
     bl require_match               // Require match and skip
 
+    bl require_global_token        // Ensure enum value exists
     adr x9, global_constant_list   // global_constant_list
     ldr x0, [x9]
     adr x9, global_token           // Using global_token
@@ -726,6 +738,8 @@ enumerator:
     ldr x0, [x0]                   // global_token->next
     adr x9, global_token           // global_token = global_token->next
     str x0, [x9]
+    cmp x0, 0                      // Check for EOF
+    b.eq enum_end                  // Let enum_end report missing }
 
     ldr x1, [x0,16]                // GLOBAL_TOKEN->S
     adr x0, comma                  // ","
@@ -739,6 +753,8 @@ enumerator:
     ldr x0, [x0]                   // global_token->next
     adr x9, global_token           // global_token = global_token->next
     str x0, [x9]
+    cmp x0, 0                      // Check for EOF
+    b.eq enum_end                  // Let enum_end report missing }
 
     ldr x1, [x0,16]                // GLOBAL_TOKEN->S
     adr x0, close_curly_brace      // "}"
@@ -761,6 +777,7 @@ program_else:
     bl type_name                // Figure out the type_size
     cmp x0, 0                   // IF NULL == type_size
     b.eq new_type               // it was a new type
+    bl require_global_token     // Missing declarator
 
     // Add to global symbol table
     mov x1, x0                  // put type_size in the right spot
@@ -777,6 +794,8 @@ program_else:
     ldr x1, [x1]                // global_token->next
     adr x9, global_token        // global_token = global_token->next
     str x1, [x9]
+    cmp x1, 0                   // Check for EOF
+    b.eq program_error          // Missing ; or function body
 
     adr x9, global_token        // Using global token
     ldr x1, [x9]
@@ -859,6 +878,7 @@ declare_function:
     str x0, [x9]
 
     bl collect_arguments        // collect all of the function arguments
+    bl require_global_token     // Ensure global_token is not EOF
 
     adr x9, global_token        // Using global token
     ldr x0, [x9]
@@ -932,6 +952,7 @@ collect_arguments:
     adr x9, global_token        // global_token = global_token->next
     str x0, [x9]
 collect_arguments_loop:
+    bl require_global_token       // Ensure global_token is not EOF
     adr x9, global_token        // Using global_token
     ldr x1, [x9]
     ldr x1, [x1,16]             // global_token->S
@@ -943,6 +964,7 @@ collect_arguments_loop:
     // deal with the case of there are arguments
     bl type_name                // Get the type
     mov x2, x0                  // put type_size safely out of the way
+    bl require_global_token     // Ensure global_token is not EOF
 
     adr x9, global_token        // Using global_token
     ldr x1, [x9]
@@ -1004,6 +1026,7 @@ collect_arguments_next:
     str x2, [x0,32]             // function->args = a
 
 collect_arguments_common:
+    bl require_global_token       // Ensure global_token is not EOF
     adr x9, global_token        // Using global_token
     ldr x1, [x9]
     ldr x1, [x1,16]             // global_token->S
@@ -1038,6 +1061,7 @@ collect_arguments_done:
 // Walks down global_token recursively to collect the contents of the function
 statement:
     push x30
+    bl require_global_token       // Ensure global_token is not EOF
     push x1                     // Protect X1
     push x2                     // Protect X2
 
@@ -1156,6 +1180,8 @@ statement_goto:
     ldr x0, [x0]                // global_token->next
     adr x9, global_token        // global_token = global_token->next
     str x0, [x9]
+    cmp x0, 0                   // Check for EOF
+    b.eq Exit_Failure           // Require a label after goto
 
     ldr x0, [x0,16]             // global_token->S
     bl emit_out                 // emit it
@@ -1251,6 +1277,7 @@ recursive_statement:
     ldr x2, [x2,8]              // frame = function->locals
 
 recursive_statement_loop:
+    bl require_global_token       // Ensure global_token is not EOF
     adr x9, global_token        // Using global_token
     ldr x1, [x9]
     ldr x1, [x1,16]             // global_token->S
@@ -1316,6 +1343,8 @@ return_result:
     ldr x0, [x0]                // global_token->next
     adr x9, global_token        // global_token = global_token->next
     str x0, [x9]
+    cmp x0, 0                   // Check for EOF
+    b.eq return_result_cleanup  // Missing ; will be reported below
 
     ldr x0, [x0,16]             // global_token->S
     ldrb w0, [x0]               // global_token->S[0]
@@ -1325,6 +1354,7 @@ return_result:
     bl expression               // get the expression we are returning
 
 return_result_cleanup:
+    bl require_global_token       // Ensure global_token is not EOF
     adr x0, return_result_string_0 // Using "ERROR in return_result\nMISSING //\n"
     adr x1, semicolon           // Using ";"
     bl require_match            // Make sure we have it
@@ -1356,9 +1386,11 @@ return_result_done:
 // Uses X2 for struct token_list* A
 collect_local:
     push x30
+    bl require_global_token       // Ensure global_token is not EOF
     push x1                     // Protect X1
     push x2                     // Protect X2
     bl type_name                // Get the local's type
+    bl require_global_token     // Missing local name
 
     mov x1, x0                  // Put struct type* type_size in the right place
     adr x9, global_token        // Using global_token
@@ -1457,6 +1489,8 @@ collect_local_common:
     ldr x0, [x0]                // global_token->NEXT
     adr x9, global_token        // global_token = global_token->NEXT
     str x0, [x9]
+    cmp x0, 0                   // Check for EOF
+    b.eq collect_local_done     // Missing ; will be reported below
 
     ldr x1, [x0,16]             // global_token->S
     adr x0, equal               // Using "="
@@ -1513,6 +1547,8 @@ process_asm:
     adr x9, global_token        // Using global_token
     ldr x1, [x9]
 process_asm_iter:
+    cmp x1, 0                   // Check for EOF
+    b.eq process_asm_done       // Missing ) will be reported below
     ldr x0, [x1,16]             // global_token->S
     ldrb w0, [x0]               // global_token->S[0]
     cmp x0, 34                  // IF global_token->S[0] == '"'
@@ -1619,6 +1655,8 @@ process_if:
 
     adr x9, global_token        // Using global_token
     ldr x1, [x9]
+    cmp x1, 0                   // Check for EOF
+    b.eq process_if_done        // No else to process
     ldr x1, [x1,16]             // global_token->S
     adr x0, else_string         // Using "else"
     bl match                    // IF global_token->S == "else"
@@ -1904,6 +1942,7 @@ process_while:
 // Uses X2 for char* NUMBER_STRING
 process_for:
     push x30
+    bl require_global_token     // Ensure global_token is not EOF
     push x1                     // Protect X1
     push x2                     // Protect X2
     bl save_break_frame         // Save the frame
@@ -1940,6 +1979,7 @@ process_for:
     adr x1, open_paren          // Using "("
     bl require_match            // Make Sure we have it
 
+    bl require_global_token     // Ensure for body is not EOF
     adr x9, global_token        // Using global_token
     ldr x1, [x9]
     ldr x1, [x1,16]             // global_token->S
@@ -2148,6 +2188,7 @@ process_break_bad:
 // Uses X0 and X1 for match and X2 for char* store
 expression:
     push x30
+    bl require_global_token       // Ensure global_token is not EOF
     push x1                     // Protect X1
     push x2                     // Protect X2
     bl bitwise_expr             // Collect bitwise expressions
@@ -2417,6 +2458,7 @@ postfix_expr:
 // Uses X0, X1, X2 and X3 for passing constants to general recursion
 postfix_expr_stub:
     push x30
+    bl require_global_token       // Ensure global_token is not EOF
     push x1                     // Protect X1
     adr x9, global_token        // Using global_token
     ldr x1, [x9]
@@ -2496,6 +2538,8 @@ postfix_expr_array:
     push x2                     // Protect X2
     adr x9, current_target      // ARRAY = current_target
     ldr x0, [x9]
+    cmp x0, 0                   // Check for bad target
+    b.eq Exit_Failure           // Cannot subscript unknown target
     push x0                     // Protect it
 
     adr x0, expression          // Using expression
@@ -2504,6 +2548,9 @@ postfix_expr_array:
     pop x1                      // Restore array
     adr x9, current_target      // current_target = ARRAY
     str x1, [x9]
+    ldr x0, [x1,24]             // current_target->INDIRECT
+    cmp x0, 0                   // Check for scalar subscript
+    b.eq Exit_Failure           // Arrays require an indirect type
 
     adr x2, postfix_expr_array_string_0 // ASSIGN = "DEREF_X0\n"
 
@@ -2525,6 +2572,8 @@ postfix_expr_array_large:
     adr x9, current_target      // Using current_target
     ldr x0, [x9]
     ldr x0, [x0,24]             // current_target->INDIRECT
+    cmp x0, 0                   // Check for scalar subscript
+    b.eq Exit_Failure           // Cannot scale without an indirect type
     ldr x0, [x0,8]              // current_target->INDIRECT->SIZE
     bl ceil_log2                // ceil_log2(current_target->indirect->size)
     bl numerate_number          // numerate_number(ceil_log2(current_target->indirect->size))
@@ -2543,6 +2592,8 @@ postfix_expr_array_common:
 
     adr x9, global_token        // Using global_token
     ldr x1, [x9]
+    cmp x1, 0                   // Check for EOF
+    b.eq postfix_expr_array_done // Treat it as not being an assignment
     ldr x1, [x1,16]             // global_token->S
     adr x0, equal               // Using "="
     bl match                    // IF global_token->S == "="
@@ -2610,10 +2661,14 @@ postfix_expr_arrow:
     ldr x0, [x0]                // global_token->NEXT
     adr x9, global_token        // global_token = global_token->NEXT
     str x0, [x9]
+    cmp x0, 0                   // Check for EOF
+    b.eq Exit_Failure           // Abort on missing member name
 
     ldr x1, [x0,16]             // Using global_token->S
     adr x9, current_target      // Using current_target
     ldr x0, [x9]
+    cmp x0, 0                   // Check for unknown target
+    b.eq Exit_Failure           // Abort hard
     bl lookup_member            // lookup_member(current_target, global_token->s)
     mov x1, x0                  // struct type* I = lookup_member(current_target, global_token->s)
 
@@ -2626,6 +2681,7 @@ postfix_expr_arrow:
     ldr x0, [x0]                // global_token->NEXT
     adr x9, global_token        // global_token = global_token->NEXT
     str x0, [x9]
+    bl require_global_token     // Ensure global_token is not EOF
 
     ldr x0, [x1,16]             // I->OFFSET
     cmp x0, 0                   // IF 0 != I->OFFSET
@@ -2650,12 +2706,15 @@ postfix_expr_arrow_first:
     // Last chance for load
     adr x9, global_token        // Using global_token
     ldr x0, [x9]
+    cmp x0, 0                   // Check for EOF
+    b.eq postfix_expr_arrow_load // Treat it as not being an assignment
     ldr x1, [x0,16]             // global_token->S
     adr x0, equal               // Using "="
     bl match                    // IF global_token->S == "="
     cmp x0, 0                   // Then we have assignment and should not load
     b.eq postfix_expr_arrow_done // Be done
 
+postfix_expr_arrow_load:
     // Deal with load case
     adr x0, postfix_expr_arrow_string_3 // Using "DEREF_X0\n"
     bl emit_out                 // Emit it
@@ -2670,6 +2729,7 @@ postfix_expr_arrow_done:
 // Returns nothing
 primary_expr:
     push x30
+    bl require_global_token       // Ensure global_token is not EOF
     push x1                     // Protect X1
 
     adr x9, global_token        // Using global_token
@@ -2825,6 +2885,7 @@ primary_expr_done:
 // Uses X0 for struct token_list* a and X2 for char* S
 primary_expr_variable:
     push x30
+    bl require_global_token       // Ensure global_token is not EOF
     push x1                     // Protect X1
     push x2                     // Protect X2
     adr x9, global_token        // Using global_token
@@ -2925,6 +2986,7 @@ primary_expr_variable_done:
 // Uses X2 for char* S, X3 for int BOOL, X5 for PASSED
 function_call:
     push x30
+    bl require_global_token       // Ensure global_token is not EOF
     push x1                     // Protect X1
     push x2                     // Protect X2
     push x3                     // Protect X3
@@ -2937,6 +2999,7 @@ function_call:
     adr x1, open_paren          // Using "("
     bl require_match            // Make sure we have it
 
+    bl require_global_token       // Ensure argument list is present
     adr x0, function_call_string_1 // Using "PUSH_X16\t# Protect a tmp register we're going to use\n"
     bl emit_out                 // Emit it
 
@@ -2964,6 +3027,7 @@ function_call:
     mov x5, 1                   // PASSED = 1
 
 function_call_gen_iter:
+    bl require_global_token       // Ensure global_token is not EOF
     adr x9, global_token        // Using global_token
     ldr x0, [x9]
     ldr x0, [x0,16]             // global_token->S
@@ -2977,6 +3041,7 @@ function_call_gen_iter:
     adr x9, global_token        // global_token = global_token->NEXT
     str x0, [x9]
 
+    bl require_global_token       // Ensure argument follows comma
     bl expression               // Collect the argument
 
     adr x0, function_call_string_5 // Using "PUSH_X0\t#_process_expression2\n"
@@ -3079,6 +3144,7 @@ variable_load:
     push x2                     // Protect X2
     mov x2, x0                  // Protect A
 
+    bl require_global_token     // EOF means not a call
     adr x9, global_token        // Using global_token
     ldr x1, [x9]
     ldr x1, [x1,16]             // global_token->S
@@ -3117,6 +3183,7 @@ variable_load_regular:
     bl emit_out                 // Emit it
 
     // Check for special case of assignment
+    bl require_global_token     // EOF means not an assignment
     adr x9, global_token        // Using global_token
     ldr x1, [x9]
     ldr x1, [x1,16]             // global_token->S
@@ -3145,6 +3212,7 @@ function_load:
     push x2                     // Protect X2
     ldr x0, [x0,16]             // A->S
     mov x2, x0                  // Protect A->S
+    bl require_global_token     // EOF means not a call
     adr x9, global_token        // Using global_token
     ldr x1, [x9]
     ldr x1, [x1,16]             // global_token->S
@@ -3199,6 +3267,7 @@ global_load:
     adr x0, global_load_string_1 // Using "\n"
     bl emit_out                 // Emit it
 
+    bl require_global_token     // EOF means not an assignment
     adr x9, global_token        // Using global_token
     ldr x1, [x9]
     ldr x1, [x1,16]             // global_token->S
@@ -3519,12 +3588,22 @@ common_recursion:
     ret
 
 
+// require_global_token function
+// Aborts if global_token is NULL before callers dereference it
+require_global_token:
+    adr x9, global_token
+    ldr x0, [x9]
+    cmp x0, 0
+    b.eq Exit_Failure
+    ret
+
 // require_match function
 // Receives char* message in X0 and char* required in X1
 // Returns nothing
 // Uses X2 to hold message and updates global_token
 require_match:
     push x30
+    bl require_global_token       // Ensure global_token is not EOF
     push x1                     // Protect X1
     push x2                     // Protect X2
     mov x2, x0                  // put the message somewhere safe
@@ -3982,6 +4061,7 @@ hex1:
 // Uses X2 for STRUCT TYPE* RET
 type_name:
     push x30
+    bl require_global_token       // Ensure global_token is not EOF
     push x1                     // Protect X1
     push x2                     // Protect X2
     adr x9, global_token        // Using global_token
@@ -3999,6 +4079,8 @@ type_name:
     ldr x1, [x1]                // global_token->next
     adr x9, global_token        // global_token = global_token->next
     str x1, [x9]
+    cmp x1, 0                   // Check for EOF
+    b.eq Exit_Failure           // Abort on missing struct name
     ldr x0, [x1,16]             // global_token->S
     adr x9, global_types        // get all known types
     ldr x1, [x9]
@@ -4041,11 +4123,14 @@ type_name_native:
     b Exit_Failure              // Abort
 
 type_name_common:
+    bl require_global_token     // Ensure global_token is not EOF
     adr x9, global_token        // Using global_token
     ldr x1, [x9]
     ldr x1, [x1]                // global_token->next
     adr x9, global_token        // global_token = global_token->next
     str x1, [x9]
+    cmp x1, 0                   // Check for EOF
+    b.eq type_name_done         // No more pointer qualifiers
 
 type_name_iter:
     ldr x0, [x1,16]             // global_token->S
@@ -4060,6 +4145,8 @@ type_name_iter:
     ldr x1, [x1]                // global_token->next
     adr x9, global_token        // global_token = global_token->next
     str x1, [x9]
+    cmp x1, 0                   // Check for EOF
+    b.eq type_name_done         // No more pointer qualifiers
     b type_name_iter            // keep looping
 
 type_name_done:
@@ -4134,6 +4221,8 @@ create_struct:
 
     str x4, [x3,24]             // HEAD->INDIRECT = I
     str x3, [x4,24]             // I->INDIRECT = HEAD
+    str x3, [x3,40]             // HEAD->TYPE = HEAD
+    str x4, [x4,40]             // I->TYPE = I
 
     adr x9, global_types        // Using global_types
     ldr x0, [x9]
@@ -4157,6 +4246,7 @@ create_struct:
     mov x5, 0                   // LAST = NULL
 
 create_struct_iter:
+    bl require_global_token       // Ensure global_token is not EOF
     adr x9, global_token        // Using global_token
     ldr x0, [x9]
     ldr x0, [x0,16]             // global_token->S
@@ -4262,6 +4352,7 @@ lookup_member_fail:
 // Uses X2 for struct type* member_type and X3 for struct type* I
 build_member:
     push x30
+    bl require_global_token       // Ensure global_token is not EOF
     push x1                     // Protect X1
     push x2                     // Protect X2
     push x3                     // Protect X3
@@ -4275,6 +4366,7 @@ build_member:
     bl type_name                // Get member_type
     mov x2, x0                  // Put in place
     str x2, [x3,40]             // I->TYPE = MEMBER_TYPE
+    bl require_global_token     // Ensure member name exists
     adr x9, global_token        // Using global_token
     ldr x0, [x9]
     ldr x1, [x0,16]             // global_token->S
@@ -4282,6 +4374,8 @@ build_member:
     ldr x0, [x0]                // global_token->NEXT
     adr x9, global_token        // global_token = global_token->NEXT
     str x0, [x9]
+    cmp x0, 0                   // Check for EOF
+    b.eq build_member_non_array // Let caller report missing semicolon
 
     // Check if we have an array
     ldr x1, [x0,16]             // global_token->S
@@ -4290,17 +4384,21 @@ build_member:
     cmp x0, 0                   // Then we have to deal with arrays in our structs
     b.eq build_member_array     // So deal with that pain
 
+build_member_non_array:
     // Deal with non-array case
     ldr x0, [x2,8]              // member_type->SIZE
     str x0, [x3,8]              // I->SIZE = member_type->SIZE
     b build_member_done         // Be done
 
 build_member_array:
+    bl require_global_token     // Ensure global_token is not EOF
     adr x9, global_token        // Using global_token
     ldr x0, [x9]
     ldr x0, [x0]                // global_token->NEXT
     adr x9, global_token        // global_token = global_token->NEXT
     str x0, [x9]
+    cmp x0, 0                   // Check for EOF
+    b.eq Exit_Failure           // Require an array size after [
 
     ldr x0, [x0,16]             // global_token->S
     bl numerate_string          // convert number

--- a/cc_aarch64.M1
+++ b/cc_aarch64.M1
@@ -354,9 +354,11 @@ DEFINE STR_X2_[X3,40]        621400f9
 DEFINE STR_X2_[X9]           220100f9
 DEFINE STR_X3_[X0,16]        030800f9
 DEFINE STR_X3_[X0,32]        031000f9
+DEFINE STR_X3_[X3,40]        631400f9
 DEFINE STR_X3_[X4,24]        830c00f9
 DEFINE STR_X3_[X9]           230100f9
 DEFINE STR_X4_[X3,24]        640c00f9
+DEFINE STR_X4_[X4,40]        841400f9
 DEFINE STR_X5_[X3,32]        651000f9
 DEFINE STR_X5_[X4,32]        851000f9
 DEFINE STR_X11_[X0]          0b0000f9
@@ -742,6 +744,9 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &C
     LDR_X0_[X9]
+    CMP_X0_TO_MINUS_4                   # Check for EOF
+    SKIP_INST_NE                        # Stop if the comment was not closed
+    ^~reset RBRANCH
     CMP_X0_TO_47                        # IF '/' != C
     SKIP_INST_NE                        # be done
     ^~get_token_comment_block_done FBRANCH
@@ -751,6 +756,9 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &C
     LDR_X0_[X9]
+    CMP_X0_TO_MINUS_4                   # Check for EOF
+    SKIP_INST_NE                        # Stop if the comment was not closed
+    ^~reset RBRANCH
     CMP_X0_TO_42                        # IF '*' != C
     SKIP_INST_NE                        # jump over
     ^~get_token_comment_block_iter FBRANCH
@@ -911,9 +919,13 @@ DEFINE RBRANCH 17
     PUSH_LR
 :purge_macro_loop
     ^~fgetc FCALL                       # read next char
+    CMP_X0_TO_MINUS_4                   # Check for EOF
+    SKIP_INST_NE                        # Done if EOF
+    ^~purge_macro_done FBRANCH
     CMP_X0_TO_10                        # Check for '\n'
     SKIP_INST_EQ                        # Keep going
     ^~purge_macro_loop RBRANCH
+:purge_macro_done
     POP_LR
     RETURN
 
@@ -1018,6 +1030,9 @@ DEFINE RBRANCH 17
 
 :consume_word_iter
     ^~consume_byte FCALL                # read next char
+    CMP_X0_TO_MINUS_4                   # Check for EOF
+    SKIP_INST_NE                        # Stop if the string was not closed
+    ^~consume_word_done FBRANCH
 
     CMP_X2_TO_0                         # IF ESCAPE
     SKIP_INST_EQ                        # keep looping
@@ -1027,6 +1042,7 @@ DEFINE RBRANCH 17
     SKIP_INST_EQ                        # keep going
     ^~consume_word_loop RBRANCH
 
+:consume_word_done
     ^~fgetc FCALL                       # return next char
     POP_X2                              # Restore X2
     POP_X1                              # Restore X1
@@ -1255,6 +1271,7 @@ DEFINE RBRANCH 17
     ^~require_match FCALL               # Require match and skip
 
 :enumerator
+    ^~require_global_token FCALL        # Ensure global_token is not EOF
     LOAD_W9_AHEAD                       # Using global_token
     SKIP_32_DATA
     &global_token
@@ -1290,6 +1307,7 @@ DEFINE RBRANCH 17
     &equal
     ^~require_match FCALL               # Require match and skip
 
+    ^~require_global_token FCALL        # Ensure enum value exists
     LOAD_W9_AHEAD                       # global_constant_list
     SKIP_32_DATA
     &global_constant_list
@@ -1309,6 +1327,9 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &global_token
     STR_X0_[X9]
+    CMP_X0_TO_0                         # Check for EOF
+    SKIP_INST_NE                        # Let enum_end report missing }
+    ^~enum_end FBRANCH
 
     LDR_X1_[X0,16]                      # GLOBAL_TOKEN->S
     LOAD_W0_AHEAD                       # ","
@@ -1329,6 +1350,9 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &global_token
     STR_X0_[X9]
+    CMP_X0_TO_0                         # Check for EOF
+    SKIP_INST_NE                        # Let enum_end report missing }
+    ^~enum_end FBRANCH
 
     LDR_X1_[X0,16]                      # GLOBAL_TOKEN->S
     LOAD_W0_AHEAD                       # "}"
@@ -1363,6 +1387,7 @@ DEFINE RBRANCH 17
     CMP_X0_TO_0                         # IF NULL == type_size
     SKIP_INST_NE                        # it was a new type
     ^~new_type RBRANCH
+    ^~require_global_token FCALL        # Missing declarator
 
     # Add to global symbol table
     SET_X1_FROM_X0                      # put type_size in the right spot
@@ -1389,6 +1414,9 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &global_token
     STR_X1_[X9]
+    CMP_X1_TO_0                         # Check for EOF
+    SKIP_INST_NE                        # Missing ; or function body
+    ^~program_error FBRANCH
 
     LOAD_W9_AHEAD                       # Using global token
     SKIP_32_DATA
@@ -1505,6 +1533,7 @@ DEFINE RBRANCH 17
     STR_X0_[X9]
 
     ^~collect_arguments FCALL           # collect all of the function arguments
+    ^~require_global_token FCALL        # Ensure global_token is not EOF
 
     LOAD_W9_AHEAD                       # Using global token
     SKIP_32_DATA
@@ -1608,6 +1637,7 @@ DEFINE RBRANCH 17
     &global_token
     STR_X0_[X9]
 :collect_arguments_loop
+    ^~require_global_token FCALL        # Ensure global_token is not EOF
     LOAD_W9_AHEAD                       # Using global_token
     SKIP_32_DATA
     &global_token
@@ -1624,6 +1654,7 @@ DEFINE RBRANCH 17
     # deal with the case of there are arguments
     ^~type_name FCALL                   # Get the type
     SET_X2_FROM_X0                      # put type_size safely out of the way
+    ^~require_global_token FCALL        # Ensure global_token is not EOF
 
     LOAD_W9_AHEAD                       # Using global_token
     SKIP_32_DATA
@@ -1710,6 +1741,7 @@ DEFINE RBRANCH 17
     STR_X2_[X0,32]                      # function->args = a
 
 :collect_arguments_common
+    ^~require_global_token FCALL        # Ensure global_token is not EOF
     LOAD_W9_AHEAD                       # Using global_token
     SKIP_32_DATA
     &global_token
@@ -1757,6 +1789,7 @@ DEFINE RBRANCH 17
 # Walks down global_token recursively to collect the contents of the function
 :statement
     PUSH_LR
+    ^~require_global_token FCALL        # Ensure global_token is not EOF
     PUSH_X1                             # Protect X1
     PUSH_X2                             # Protect X2
 
@@ -1919,6 +1952,9 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &global_token
     STR_X0_[X9]
+    CMP_X0_TO_0                         # Check for EOF
+    SKIP_INST_NE                        # Require a label after goto
+    ^~Exit_Failure FBRANCH
 
     LDR_X0_[X0,16]                      # global_token->S
     ^~emit_out FCALL                    # emit it
@@ -2055,6 +2091,7 @@ DEFINE RBRANCH 17
     LDR_X2_[X2,8]                       # frame = function->locals
 
 :recursive_statement_loop
+    ^~require_global_token FCALL        # Ensure global_token is not EOF
     LOAD_W9_AHEAD                       # Using global_token
     SKIP_32_DATA
     &global_token
@@ -2145,6 +2182,9 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &global_token
     STR_X0_[X9]
+    CMP_X0_TO_0                         # Check for EOF
+    SKIP_INST_NE                        # Missing ; will be reported below
+    ^~return_result_cleanup FBRANCH
 
     LDR_X0_[X0,16]                      # global_token->S
     LDR_BYTE_W0_[X0]                    # global_token->S[0]
@@ -2155,6 +2195,7 @@ DEFINE RBRANCH 17
     ^~expression FCALL                  # get the expression we are returning
 
 :return_result_cleanup
+    ^~require_global_token FCALL        # Ensure global_token is not EOF
     LOAD_W0_AHEAD                       # Using "ERROR in return_result\nMISSING ;\n"
     SKIP_32_DATA
     &return_result_string_0
@@ -2197,9 +2238,11 @@ DEFINE RBRANCH 17
 # Uses X2 for struct token_list* A
 :collect_local
     PUSH_LR
+    ^~require_global_token FCALL        # Ensure global_token is not EOF
     PUSH_X1                             # Protect X1
     PUSH_X2                             # Protect X2
     ^~type_name FCALL                   # Get the local's type
+    ^~require_global_token FCALL        # Missing local name
 
     SET_X1_FROM_X0                      # Put struct type* type_size in the right place
     LOAD_W9_AHEAD                       # Using global_token
@@ -2335,6 +2378,9 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &global_token
     STR_X0_[X9]
+    CMP_X0_TO_0                         # Check for EOF
+    SKIP_INST_NE                        # Missing ; will be reported below
+    ^~collect_local_done FBRANCH
 
     LDR_X1_[X0,16]                      # global_token->S
     LOAD_W0_AHEAD                       # Using "="
@@ -2416,6 +2462,9 @@ DEFINE RBRANCH 17
     &global_token
     LDR_X1_[X9]
 :process_asm_iter
+    CMP_X1_TO_0                         # Check for EOF
+    SKIP_INST_NE                        # Missing ) will be reported below
+    ^~process_asm_done FBRANCH
     LDR_X0_[X1,16]                      # global_token->S
     LDR_BYTE_W0_[X0]                    # global_token->S[0]
     CMP_X0_TO_34                        # IF global_token->S[0] == '\"'
@@ -2571,6 +2620,9 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &global_token
     LDR_X1_[X9]
+    CMP_X1_TO_0                         # Check for EOF
+    SKIP_INST_NE                        # No else to process
+    ^~process_if_done FBRANCH
     LDR_X1_[X1,16]                      # global_token->S
     LOAD_W0_AHEAD                       # Using "else"
     SKIP_32_DATA
@@ -2976,6 +3028,7 @@ DEFINE RBRANCH 17
 # Uses X2 for char* NUMBER_STRING
 :process_for
     PUSH_LR
+    ^~require_global_token FCALL        # Ensure global_token is not EOF
     PUSH_X1                             # Protect X1
     PUSH_X2                             # Protect X2
     ^~save_break_frame RCALL            # Save the frame
@@ -3030,6 +3083,7 @@ DEFINE RBRANCH 17
     &open_paren
     ^~require_match FCALL               # Make Sure we have it
 
+    ^~require_global_token FCALL        # Ensure for body is not EOF
     LOAD_W9_AHEAD                       # Using global_token
     SKIP_32_DATA
     &global_token
@@ -3330,6 +3384,7 @@ DEFINE RBRANCH 17
 # Uses X0 and X1 for match and X2 for char* store
 :expression
     PUSH_LR
+    ^~require_global_token FCALL        # Ensure global_token is not EOF
     PUSH_X1                             # Protect X1
     PUSH_X2                             # Protect X2
     ^~bitwise_expr FCALL                # Collect bitwise expressions
@@ -3766,6 +3821,7 @@ DEFINE RBRANCH 17
 # Uses X0, X1, X2 and X3 for passing constants to general recursion
 :postfix_expr_stub
     PUSH_LR
+    ^~require_global_token FCALL        # Ensure global_token is not EOF
     PUSH_X1                             # Protect X1
     LOAD_W9_AHEAD                       # Using global_token
     SKIP_32_DATA
@@ -3871,6 +3927,9 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &current_target
     LDR_X0_[X9]
+    CMP_X0_TO_0                         # Check for bad target
+    SKIP_INST_NE                        # Cannot subscript unknown target
+    ^~Exit_Failure FBRANCH
     PUSH_X0                             # Protect it
 
     LOAD_W0_AHEAD                       # Using expression
@@ -3883,6 +3942,10 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &current_target
     STR_X1_[X9]
+    LDR_X0_[X1,24]                      # current_target->INDIRECT
+    CMP_X0_TO_0                         # Check for scalar subscript
+    SKIP_INST_NE                        # Arrays require an indirect type
+    ^~Exit_Failure FBRANCH
 
     LOAD_W2_AHEAD                       # ASSIGN = "DEREF_X0\n"
     SKIP_32_DATA
@@ -3915,6 +3978,9 @@ DEFINE RBRANCH 17
     &current_target
     LDR_X0_[X9]
     LDR_X0_[X0,24]                      # current_target->INDIRECT
+    CMP_X0_TO_0                         # Check for scalar subscript
+    SKIP_INST_NE                        # Cannot scale without an indirect type
+    ^~Exit_Failure FBRANCH
     LDR_X0_[X0,8]                       # current_target->INDIRECT->SIZE
     ^~ceil_log2 FCALL                   # ceil_log2(current_target->indirect->size)
     ^~numerate_number FCALL             # numerate_number(ceil_log2(current_target->indirect->size))
@@ -3943,6 +4009,9 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &global_token
     LDR_X1_[X9]
+    CMP_X1_TO_0                         # Check for EOF
+    SKIP_INST_NE                        # Treat it as not being an assignment
+    ^~postfix_expr_array_done FBRANCH
     LDR_X1_[X1,16]                      # global_token->S
     LOAD_W0_AHEAD                       # Using "="
     SKIP_32_DATA
@@ -4023,12 +4092,18 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &global_token
     STR_X0_[X9]
+    CMP_X0_TO_0                         # Check for EOF
+    SKIP_INST_NE                        # Abort on missing member name
+    ^~Exit_Failure FBRANCH
 
     LDR_X1_[X0,16]                      # Using global_token->S
     LOAD_W9_AHEAD                       # Using current_target
     SKIP_32_DATA
     &current_target
     LDR_X0_[X9]
+    CMP_X0_TO_0                         # Check for unknown target
+    SKIP_INST_NE                        # Abort hard
+    ^~Exit_Failure FBRANCH
     ^~lookup_member FCALL               # lookup_member(current_target, global_token->s)
     SET_X1_FROM_X0                      # struct type* I = lookup_member(current_target, global_token->s)
 
@@ -4047,6 +4122,7 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &global_token
     STR_X0_[X9]
+    ^~require_global_token FCALL        # Ensure global_token is not EOF
 
     LDR_X0_[X1,16]                      # I->OFFSET
     CMP_X0_TO_0                         # IF 0 != I->OFFSET
@@ -4079,6 +4155,9 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &global_token
     LDR_X0_[X9]
+    CMP_X0_TO_0                         # Check for EOF
+    SKIP_INST_NE                        # Treat it as not being an assignment
+    ^~postfix_expr_arrow_load FBRANCH
     LDR_X1_[X0,16]                      # global_token->S
     LOAD_W0_AHEAD                       # Using "="
     SKIP_32_DATA
@@ -4088,6 +4167,7 @@ DEFINE RBRANCH 17
     SKIP_INST_NE                        # Be done
     ^~postfix_expr_arrow_done FBRANCH
 
+:postfix_expr_arrow_load
     # Deal with load case
     LOAD_W0_AHEAD                       # Using "DEREF_X0\n"
     SKIP_32_DATA
@@ -4104,6 +4184,7 @@ DEFINE RBRANCH 17
 # Returns nothing
 :primary_expr
     PUSH_LR
+    ^~require_global_token FCALL        # Ensure global_token is not EOF
     PUSH_X1                             # Protect X1
 
     LOAD_W9_AHEAD                       # Using global_token
@@ -4316,6 +4397,7 @@ DEFINE RBRANCH 17
 # Uses X0 for struct token_list* a and X2 for char* S
 :primary_expr_variable
     PUSH_LR
+    ^~require_global_token FCALL        # Ensure global_token is not EOF
     PUSH_X1                             # Protect X1
     PUSH_X2                             # Protect X2
     LOAD_W9_AHEAD                       # Using global_token
@@ -4441,6 +4523,7 @@ DEFINE RBRANCH 17
 # Uses X2 for char* S, X3 for int BOOL, X5 for PASSED
 :function_call
     PUSH_LR
+    ^~require_global_token FCALL        # Ensure global_token is not EOF
     PUSH_X1                             # Protect X1
     PUSH_X2                             # Protect X2
     PUSH_X3                             # Protect X3
@@ -4457,6 +4540,7 @@ DEFINE RBRANCH 17
     &open_paren
     ^~require_match FCALL               # Make sure we have it
 
+    ^~require_global_token FCALL        # Ensure argument list is present
     LOAD_W0_AHEAD                       # Using "PUSH_X16\t# Protect a tmp register we're going to use\n"
     SKIP_32_DATA
     &function_call_string_1
@@ -4497,6 +4581,7 @@ DEFINE RBRANCH 17
     SET_X5_TO_1                         # PASSED = 1
 
 :function_call_gen_iter
+    ^~require_global_token FCALL        # Ensure global_token is not EOF
     LOAD_W9_AHEAD                       # Using global_token
     SKIP_32_DATA
     &global_token
@@ -4517,6 +4602,7 @@ DEFINE RBRANCH 17
     &global_token
     STR_X0_[X9]
 
+    ^~require_global_token FCALL        # Ensure argument follows comma
     ^~expression RCALL                  # Collect the argument
 
     LOAD_W0_AHEAD                       # Using "PUSH_X0\t#_process_expression2\n"
@@ -4659,6 +4745,7 @@ DEFINE RBRANCH 17
     PUSH_X2                             # Protect X2
     SET_X2_FROM_X0                      # Protect A
 
+    ^~require_global_token FCALL        # EOF means not a call
     LOAD_W9_AHEAD                       # Using global_token
     SKIP_32_DATA
     &global_token
@@ -4711,6 +4798,7 @@ DEFINE RBRANCH 17
     ^~emit_out FCALL                    # Emit it
 
     # Check for special case of assignment
+    ^~require_global_token FCALL        # EOF means not an assignment
     LOAD_W9_AHEAD                       # Using global_token
     SKIP_32_DATA
     &global_token
@@ -4746,6 +4834,7 @@ DEFINE RBRANCH 17
     PUSH_X2                             # Protect X2
     LDR_X0_[X0,16]                      # A->S
     SET_X2_FROM_X0                      # Protect A->S
+    ^~require_global_token FCALL        # EOF means not a call
     LOAD_W9_AHEAD                       # Using global_token
     SKIP_32_DATA
     &global_token
@@ -4815,6 +4904,7 @@ DEFINE RBRANCH 17
     &global_load_string_1
     ^~emit_out FCALL                    # Emit it
 
+    ^~require_global_token FCALL        # EOF means not an assignment
     LOAD_W9_AHEAD                       # Using global_token
     SKIP_32_DATA
     &global_token
@@ -5218,12 +5308,25 @@ DEFINE RBRANCH 17
     RETURN
 
 
+# require_global_token function
+# Aborts if global_token is NULL before callers dereference it
+:require_global_token
+    LOAD_W9_AHEAD                       # Using global_token
+    SKIP_32_DATA
+    &global_token
+    LDR_X0_[X9]
+    CMP_X0_TO_0                         # Check for EOF
+    SKIP_INST_NE                        # Abort on EOF
+    ^~Exit_Failure FBRANCH
+    RETURN
+
 # require_match function
 # Receives char* message in X0 and char* required in X1
 # Returns nothing
 # Uses X2 to hold message and updates global_token
 :require_match
     PUSH_LR
+    ^~require_global_token RCALL        # Ensure global_token is not EOF
     PUSH_X1                             # Protect X1
     PUSH_X2                             # Protect X2
     SET_X2_FROM_X0                      # put the message somewhere safe
@@ -5735,6 +5838,7 @@ DEFINE RBRANCH 17
 # Uses X2 for STRUCT TYPE* RET
 :type_name
     PUSH_LR
+    ^~require_global_token RCALL        # Ensure global_token is not EOF
     PUSH_X1                             # Protect X1
     PUSH_X2                             # Protect X2
     LOAD_W9_AHEAD                       # Using global_token
@@ -5761,6 +5865,9 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &global_token
     STR_X1_[X9]
+    CMP_X1_TO_0                         # Check for EOF
+    SKIP_INST_NE                        # Abort on missing struct name
+    ^~Exit_Failure FBRANCH
     LDR_X0_[X1,16]                      # global_token->S
     LOAD_W9_AHEAD                       # get all known types
     SKIP_32_DATA
@@ -5815,6 +5922,7 @@ DEFINE RBRANCH 17
     ^~Exit_Failure FBRANCH              # Abort
 
 :type_name_common
+    ^~require_global_token RCALL        # Ensure global_token is not EOF
     LOAD_W9_AHEAD                       # Using global_token
     SKIP_32_DATA
     &global_token
@@ -5824,6 +5932,9 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &global_token
     STR_X1_[X9]
+    CMP_X1_TO_0                         # Check for EOF
+    SKIP_INST_NE                        # No more pointer qualifiers
+    ^~type_name_done FBRANCH
 
 :type_name_iter
     LDR_X0_[X1,16]                      # global_token->S
@@ -5843,6 +5954,9 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &global_token
     STR_X1_[X9]
+    CMP_X1_TO_0                         # Check for EOF
+    SKIP_INST_NE                        # No more pointer qualifiers
+    ^~type_name_done FBRANCH
     ^~type_name_iter RBRANCH            # keep looping
 
 :type_name_done
@@ -5921,6 +6035,8 @@ DEFINE RBRANCH 17
 
     STR_X4_[X3,24]                      # HEAD->INDIRECT = I
     STR_X3_[X4,24]                      # I->INDIRECT = HEAD
+    STR_X3_[X3,40]                      # HEAD->TYPE = HEAD
+    STR_X4_[X4,40]                      # I->TYPE = I
 
     LOAD_W9_AHEAD                       # Using global_types
     SKIP_32_DATA
@@ -5956,6 +6072,7 @@ DEFINE RBRANCH 17
     SET_X5_TO_0                         # LAST = NULL
 
 :create_struct_iter
+    ^~require_global_token RCALL        # Ensure global_token is not EOF
     LOAD_W9_AHEAD                       # Using global_token
     SKIP_32_DATA
     &global_token
@@ -6088,6 +6205,7 @@ DEFINE RBRANCH 17
 # Uses X2 for struct type* member_type and X3 for struct type* I
 :build_member
     PUSH_LR
+    ^~require_global_token RCALL        # Ensure global_token is not EOF
     PUSH_X1                             # Protect X1
     PUSH_X2                             # Protect X2
     PUSH_X3                             # Protect X3
@@ -6101,6 +6219,7 @@ DEFINE RBRANCH 17
     ^~type_name RCALL                   # Get member_type
     SET_X2_FROM_X0                      # Put in place
     STR_X2_[X3,40]                      # I->TYPE = MEMBER_TYPE
+    ^~require_global_token RCALL        # Ensure member name exists
     LOAD_W9_AHEAD                       # Using global_token
     SKIP_32_DATA
     &global_token
@@ -6112,6 +6231,9 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &global_token
     STR_X0_[X9]
+    CMP_X0_TO_0                         # Check for EOF
+    SKIP_INST_NE                        # Let caller report missing semicolon
+    ^~build_member_non_array FBRANCH
 
     # Check if we have an array
     LDR_X1_[X0,16]                      # global_token->S
@@ -6123,12 +6245,14 @@ DEFINE RBRANCH 17
     SKIP_INST_NE                        # So deal with that pain
     ^~build_member_array FBRANCH
 
+:build_member_non_array
     # Deal with non-array case
     LDR_X0_[X2,8]                       # member_type->SIZE
     STR_X0_[X3,8]                       # I->SIZE = member_type->SIZE
     ^~build_member_done FBRANCH         # Be done
 
 :build_member_array
+    ^~require_global_token RCALL        # Ensure global_token is not EOF
     LOAD_W9_AHEAD                       # Using global_token
     SKIP_32_DATA
     &global_token
@@ -6138,6 +6262,9 @@ DEFINE RBRANCH 17
     SKIP_32_DATA
     &global_token
     STR_X0_[X9]
+    CMP_X0_TO_0                         # Check for EOF
+    SKIP_INST_NE                        # Require an array size after [
+    ^~Exit_Failure FBRANCH
 
     LDR_X0_[X0,16]                      # global_token->S
     ^~numerate_string FCALL             # convert number

--- a/test/cc_aarch64-fuzz.sh
+++ b/test/cc_aarch64-fuzz.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+set -eu
+
+tmp=${TMPDIR:-/tmp}/cc_aarch64-fuzz.$$
+mkdir -p "$tmp"
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+M1=${M1:-M1}
+HEX2=${HEX2:-hex2}
+QEMU=${QEMU:-qemu-aarch64}
+
+if ! command -v "$QEMU" >/dev/null 2>&1; then
+	echo "skipping: $QEMU not found"
+	exit 0
+fi
+
+"$M1" --little-endian --architecture aarch64 \
+	-f cc_aarch64.M1 \
+	-o "$tmp/cc_aarch64.hex2"
+"$HEX2" --little-endian --architecture aarch64 \
+	--base-address 0x100000 \
+	-f ELF-aarch64.hex2 \
+	-f "$tmp/cc_aarch64.hex2" \
+	-o "$tmp/cc_aarch64-m1"
+chmod +x "$tmp/cc_aarch64-m1"
+
+targets="$tmp/cc_aarch64-m1"
+if command -v aarch64-linux-gnu-as >/dev/null 2>&1 && command -v aarch64-linux-gnu-ld >/dev/null 2>&1; then
+	aarch64-linux-gnu-as GAS/cc_aarch64.S -o "$tmp/cc_aarch64.o"
+	aarch64-linux-gnu-ld "$tmp/cc_aarch64.o" -o "$tmp/cc_aarch64-gas"
+	targets="$targets $tmp/cc_aarch64-gas"
+elif command -v clang >/dev/null 2>&1; then
+	clang --target=aarch64-linux-gnu -nostdlib -static -fuse-ld=lld \
+		GAS/cc_aarch64.S -o "$tmp/cc_aarch64-gas"
+	targets="$targets $tmp/cc_aarch64-gas"
+else
+	echo "skipping GAS/cc_aarch64.S: no aarch64 assembler or clang found"
+fi
+
+check_no_crash()
+{
+	name=$1
+	input=$2
+	for target in $targets; do
+		printf '%s' "$input" > "$tmp/$name.c"
+		set +e
+		timeout 2 "$QEMU" "$target" "$tmp/$name.c" "$tmp/$name.M1" >/dev/null 2>&1
+		status=$?
+		set -e
+		if [ "$status" -eq 124 ]; then
+			echo "$name timed out for $target"
+			exit 1
+		fi
+		if [ "$status" -ge 128 ]; then
+			echo "$name crashed with status $status for $target"
+			exit 1
+		fi
+	done
+}
+
+check_no_crash unterminated-string '"'
+check_no_crash line-comment-eof 'int#main() { return 0; }'
+check_no_crash block-comment-eof '/*'
+check_no_crash global-declarator-eof 'int 0'
+check_no_crash global-open-paren-eof 'int('
+check_no_crash global-close-brace-eof 'int}'
+check_no_crash global-quote-eof 'int"'
+check_no_crash global-single-quote-eof "int'"
+check_no_crash function-arguments-eof 'int 0('
+check_no_crash function-declaration-eof 'int 0()'
+check_no_crash function-expression-eof 'int 0()0'
+check_no_crash function-return-eof 'int 0()return'
+check_no_crash function-body-eof 'int 0(){'
+check_no_crash function-body-statement-eof 'int 0(){0;'
+check_no_crash function-if-eof 'int 0()if(0)'
+check_no_crash function-return-unary-eof 'int 0()return~'
+check_no_crash function-local-name-eof 'int 0()int'
+check_no_crash function-global-load-eof 'int x;int 0()x'
+check_no_crash function-name-load-eof 'int n()n'
+check_no_crash function-local-delimiter-eof 'int 0(){0;int}'
+check_no_crash function-local-declaration-eof 'int 0()int 0'
+check_no_crash function-if-no-else-eof 'int 0()if(0)0;'
+check_no_crash function-array-target-eof 'int 0()0[0'
+check_no_crash function-call-open-eof 'int m0in()return m0in('
+check_no_crash function-local-load-eof 'int 0(){int i;i'
+check_no_crash enum-open-eof 'enum {'
+check_no_crash enum-value-eof 'enum { A ='
+check_no_crash enum-comma-eof 'enum { A = 1,'
+check_no_crash asm-open-eof 'int main() asm('
+check_no_crash asm-string-eof 'int main() asm("x"'
+check_no_crash for-open-eof 'int main() for('
+check_no_crash sizeof-open-eof 'int main() return sizeof('
+check_no_crash struct-open-eof 'struct s {'
+check_no_crash struct-member-type-eof 'struct s { int'
+check_no_crash struct-array-open-eof 'struct s { int x['
+check_no_crash arrow-member-eof 'struct s { int x; }; int main(){ struct s *p; p->'
+check_no_crash arrow-load-eof 'struct s { int x; }; int main(){ struct s *p; p->x'
+check_no_crash goto-label-eof 'int main() goto'
+check_no_crash scalar-array-index-eof 'int n(){int x;x[0]'
+check_no_crash struct-array-load-eof 'struct S{char*s;int y[4];};int n(){struct S*p;p->s="";return p->y[0]'
+check_no_crash scalar-arrow-member-eof 'int n(){int x;1->y'
+check_no_crash struct-array-member-type-eof 'struct S{S e[a'


### PR DESCRIPTION
Harden the bootstrap compiler against malformed/truncated input discovered by fuzzing.
This adds EOF/null guards so invalid source fails cleanly instead of crashing.
