### PR TITLE
Fix stale token buffer suffixes

### DIFF
--- a/GAS/cc_aarch64.S
+++ b/GAS/cc_aarch64.S
@@ -514,6 +514,8 @@ consume_byte:
     ldr x1, [x9]
     strb w0, [x1]               // S[0] = C
     add x1, x1, 1               // S = S + 1
+    mov x0, 0                   // NULL terminate S
+    strb w0, [x1]               // S[0] = NULL
     adr x9, string_index        // Update S
     str x1, [x9]
     bl fgetc

--- a/cc_aarch64.M1
+++ b/cc_aarch64.M1
@@ -1063,6 +1063,8 @@ DEFINE RBRANCH 17
     LDR_X1_[X9]
     STR_BYTE_W0_[X1]                    # S[0] = C
     ADD_X1_X1_1                         # S = S + 1
+    SET_X0_TO_0                         # NULL terminate S
+    STR_BYTE_W0_[X1]                    # S[0] = NULL
     LOAD_W9_AHEAD                       # Update S
     SKIP_32_DATA
     &string_index


### PR DESCRIPTION
NUL-terminate the token buffer after each consumed byte so shorter tokens cannot retain stale suffix data.